### PR TITLE
Fallback of jdk from 23 to 21 (for LTS),

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,11 +13,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Oracle JDK 23
+      - name: Set up Oracle JDK 21
         uses: oracle-actions/setup-java@v1
         with:
           website: oracle.com
-          release: 23
+          release: 21
 
       - name: Build with Maven
         run: mvn clean package
@@ -30,6 +30,9 @@ jobs:
         with:
           tag_name: ${{ github.ref_name }}
           name: Release ${{ github.ref_name }}
+          body:
+                This is the release of Alohomora version ${{ github.ref_name }}.
+                The JAR file is attached below.
           files: target/Alohomora-${{ github.ref_name }}.jar
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -8,7 +8,7 @@
       </list>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_23" default="true" project-jdk-name="23" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="21" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The new functionality allows you to pass arguments to a running application inst
 
 ## Prerequisites
 
-- Java Development Kit (JDK 21) 
+- Java Development Kit (JDK 21 or later)
 - Maven (for building the project)
 
 ## License

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Alohomora is a Java-based application designed to help you manage your files by 
    cd Alohomora
    ```
 
-3. If this doesn't work, try:
+   If this doesn't work, try:
    ```bash
    cd alohomora
    ```
@@ -67,7 +67,7 @@ The new functionality allows you to pass arguments to a running application inst
 
 ## Prerequisites
 
-- Java Development Kit (JDK 23)
+- Java Development Kit (JDK 21) 
 - Maven (for building the project)
 
 ## License

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>io.github.dayfit</groupId>
     <artifactId>Alohomora</artifactId>
-    <version>0.1.0</version>
+    <version>0.1.3</version>
     <packaging>jar</packaging>
 
     <build>
@@ -65,8 +65,8 @@
     </dependencies>
 
     <properties>
-        <maven.compiler.source>23</maven.compiler.source>
-        <maven.compiler.target>23</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>


### PR DESCRIPTION
This pull request includes several changes to update the Java Development Kit (JDK) version from 23 to 21, improve the release workflow, and refactor the `Encryptor` class. Below are the most important changes:

### JDK Version Update:
* Updated the JDK version from 23 to 21 in `.github/workflows/release.yml` for the Oracle JDK setup.
* Updated the JDK version from 23 to 21 in `.idea/misc.xml` for the project configuration.
* Updated the JDK version from 23 to 21 in `pom.xml` for the Maven compiler settings.
* Updated the JDK version from 23 to 21 in `README.md` for the prerequisites section.

### Release Workflow Improvement:
* Added a body to the release description in `.github/workflows/release.yml` to include a message and attach the JAR file.

### `Encryptor` Class Refactoring:
* Removed the static initialization block for the `Cipher` instance and moved the cipher initialization into a new `handleEncryptionDecryption` method.
* Refactored the `encrypt` and `decrypt` methods to use the new `handleEncryptionDecryption` method, simplifying the code and improving maintainability. [[1]](diffhunk://#diff-f22174199e03ebcaa6307b9a318a37cb955274482b41435914899f898d9ab42dL66-R61) [[2]](diffhunk://#diff-f22174199e03ebcaa6307b9a318a37cb955274482b41435914899f898d9ab42dR115-R161)

### Miscellaneous:
* Updated the project version in `pom.xml` from 0.1.0 to 0.1.3.
* Minor correction in `README.md` to improve clarity in the usage instructions.